### PR TITLE
feat: Add macOS platform support (ARM64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ godot3dtiles/addons/cesium_godot/lib/*
 !godot-html/ultralight/lib/*.lib
 !cesium_godot/third_party/litehtml/*.lib
 
+# macOS litehtml build (built from source on macOS)
+cesium_godot/third_party/litehtml/macos/
+cesium_godot/third_party/litehtml-src/
+
 # Ignore any project import files 
 godot3dtiles/**/*.uid
 godot3dtiles/**/*.import

--- a/CesiumBuildUtils.py
+++ b/CesiumBuildUtils.py
@@ -24,6 +24,23 @@ OS_WIN = "nt"
 
 OS_LINUX = "posix"
 
+OS_MACOS = "darwin"
+
+
+def is_macos() -> bool:
+    """Check if we're running on macOS using sys.platform (more reliable than os.name)"""
+    return sys.platform == OS_MACOS
+
+
+def is_windows() -> bool:
+    """Check if we're running on Windows"""
+    return os.name == OS_WIN
+
+
+def is_linux() -> bool:
+    """Check if we're running on Linux (but not macOS)"""
+    return os.name == OS_LINUX and not is_macos()
+
 STATIC_TRIPLET = "x64-windows-static"
 
 RELEASE_CONFIG = "Release"
@@ -32,15 +49,20 @@ ezvcpkgFoundPath: str = ""
 
 
 def get_compile_flags():
-    if os.name == OS_WIN:
+    if is_windows():
         return ["/std:c++20", "/Zc:__cplusplus", "/utf-8", "/bigobj"]
-    elif os.name == OS_LINUX:
+    elif is_macos():
+        return ["-std=c++20", "-fexceptions", "-fPIC", "-mmacosx-version-min=11.0"]
+    elif is_linux():
         return ["-std=c++20", "-fexceptions", "-fpermissive", "-fPIC"]
+    return []
 
 
 def get_linker_flags():
-    if os.name == OS_WIN:
+    if is_windows():
         return ["/IGNORE:4217"]
+    elif is_macos():
+        return ["-mmacosx-version-min=11.0"]
     return []
 
 
@@ -49,7 +71,7 @@ def is_extension_target(argsDict) -> bool:
 
 
 def get_curl_lib_name() -> str:
-    if os.name == OS_WIN:
+    if is_windows():
         return "libcurl"
     return "curl"
 
@@ -122,6 +144,31 @@ def link_abseil_libs(env):
     env.Append(LINKFLAGS=["-Wl,--end-group"])
 
 
+def link_macos_frameworks(env):
+    """Link required macOS frameworks for networking and security"""
+    frameworks = [
+        "Security",
+        "CoreFoundation",
+        "SystemConfiguration",
+    ]
+    for framework in frameworks:
+        env.Append(LINKFLAGS=["-framework", framework])
+
+
+def link_abseil_libs_macos(env):
+    """Link Abseil libraries on macOS (doesn't use --start-group/--end-group)"""
+    foundLibs: list = env.Glob(
+        f"{find_ezvcpkg_path()}/packages/abseil_{determine_triplet()}/lib/*absl*.a"
+    )
+
+    # Strip the lib prefix and the file extension
+    foundLibs = [lib.name.replace("lib", "")[:-2] for lib in foundLibs]
+
+    # macOS doesn't support --start-group/--end-group, but usually doesn't need them
+    # due to different linker behavior
+    env.Append(LIBS=foundLibs)
+
+
 def clone_native_repo_if_needed():
     clone_repo_if_needed(
         ROOT_DIR_EXT + "/native",
@@ -146,6 +193,110 @@ def clone_lite_html_if_needed():
     # clone_repo_if_needed(ROOT_DIR_EXT + "/third_party/lite-html", "Lite HTML",
     #                      "https://github.com/litehtml/litehtml.git", "v0.9", "6ca1ab0419e770e6d35a1ef690238773a1dafcee")
     pass
+
+
+def build_litehtml_macos():
+    """Build litehtml from source for macOS with utf32 support.
+
+    The vcpkg version (0.9.0) doesn't have the utf32_to_utf8/utf8_to_utf32 classes
+    that the codebase requires. We need to build from a newer commit.
+    """
+    if not is_macos():
+        return
+
+    import multiprocessing
+    import shutil
+    from pathlib import Path
+
+    third_party_dir = scons_to_abs_path(ROOT_DIR_EXT + "/third_party")
+    litehtml_dir = os.path.join(third_party_dir, "litehtml-src")
+    build_dir = os.path.join(litehtml_dir, "build")
+    # Put macOS libraries in a separate directory to avoid overwriting Linux precompiled binaries
+    macos_lib_dir = os.path.join(third_party_dir, "litehtml", "macos")
+    os.makedirs(macos_lib_dir, exist_ok=True)
+    output_lib = os.path.join(macos_lib_dir, "liblitehtml.a")
+    output_gumbo = os.path.join(macos_lib_dir, "libgumbo.a")
+
+    # Check if already built
+    if os.path.exists(output_lib):
+        # Verify it's a Mach-O file
+        result = subprocess.run(["file", output_lib], capture_output=True, text=True)
+        if "Mach-O" in result.stdout:
+            print("[litehtml] macOS library already exists, skipping build")
+            return
+
+    print("[litehtml] Building litehtml from source for macOS...")
+
+    # Clone litehtml at the specific commit that matches the third_party headers
+    # Commit 35ecd69d has the utf32 functions and uses int parameters (not float)
+    # The vcpkg version (0.9.0) uses wchar instead of utf32, which is incompatible
+    litehtml_commit = "35ecd69d05e72b0148204a576db62c2148084193"
+    if not os.path.exists(litehtml_dir):
+        print(f"[litehtml] Cloning litehtml at commit {litehtml_commit[:8]}...")
+        subprocess.run([
+            "git", "clone",
+            "https://github.com/litehtml/litehtml.git",
+            litehtml_dir
+        ])
+        # Fetch all history to get the specific commit
+        subprocess.run(["git", "-C", litehtml_dir, "fetch", "--unshallow"], check=False)
+        subprocess.run(["git", "-C", litehtml_dir, "checkout", litehtml_commit])
+        subprocess.run(["git", "-C", litehtml_dir, "submodule", "update", "--init", "--recursive"])
+
+    # Create build directory
+    os.makedirs(build_dir, exist_ok=True)
+    prev_dir = os.getcwd()
+    os.chdir(build_dir)
+
+    try:
+        # Configure with CMake
+        cmake_args = [
+            "cmake",
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0",
+            "-DLITEHTML_BUILD_TESTING=OFF",
+            ".."
+        ]
+
+        # Set architecture for cross-compilation if needed
+        import platform
+        arch = platform.machine()
+        if arch == "arm64":
+            cmake_args.insert(-1, "-DCMAKE_OSX_ARCHITECTURES=arm64")
+        elif arch == "x86_64":
+            cmake_args.insert(-1, "-DCMAKE_OSX_ARCHITECTURES=x86_64")
+
+        print("[litehtml] Configuring with CMake...")
+        result = subprocess.run(cmake_args)
+        if result.returncode != 0:
+            print("[litehtml] CMake configuration failed!")
+            return
+
+        # Build
+        num_jobs = multiprocessing.cpu_count()
+        print(f"[litehtml] Building with {num_jobs} parallel jobs...")
+        result = subprocess.run(["cmake", "--build", ".", "--parallel", str(num_jobs)])
+        if result.returncode != 0:
+            print("[litehtml] Build failed!")
+            return
+
+        # Copy built libraries to third_party/litehtml
+        built_litehtml = os.path.join(build_dir, "liblitehtml.a")
+        # gumbo is a submodule built in src/gumbo/
+        built_gumbo = os.path.join(build_dir, "src", "gumbo", "libgumbo.a")
+
+        if os.path.exists(built_litehtml):
+            shutil.copy2(built_litehtml, output_lib)
+            print(f"[litehtml] Copied liblitehtml.a to {output_lib}")
+
+        if os.path.exists(built_gumbo):
+            shutil.copy2(built_gumbo, output_gumbo)
+            print(f"[litehtml] Copied libgumbo.a to {output_gumbo}")
+
+        print("[litehtml] Build complete!")
+
+    finally:
+        os.chdir(prev_dir)
 
 
 def clone_repo_if_needed(
@@ -173,23 +324,43 @@ def configure_native(argumentsDict):
     repoDirectory = CESIUM_NATIVE_DIR_EXT if isExt else CESIUM_NATIVE_DIR_MODULE
     repoDirectory = scons_to_abs_path(repoDirectory)
     os.chdir(repoDirectory)
-    # Assume you already have the triplet (for now)
-    triplet: str = determine_triplet()
-    os.environ["VCPKG_TRIPLET"] = triplet
-    # Run Cmake with the /MT flag on
-    result = subprocess.run(
-        [
-            "cmake",
-            f"-DCMAKE_BUILD_TYPE={RELEASE_CONFIG}",
-            "-DCESIUM_MSVC_STATIC_RUNTIME_ENABLED=ON",
-            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
-            "-DGIT_LFS_SKIP_SMUDGE=1",
-            "-DVCPKG_TRIPLET=%s" % triplet,
-            ".",
-        ]
-    )
 
-    # We pray this works haha
+    # Get architecture from arguments if provided
+    arch = argumentsDict.get("arch", None)
+    triplet: str = determine_triplet(arch)
+
+    if triplet is None:
+        print(f"Error: Could not determine vcpkg triplet for platform {sys.platform}", file=sys.stderr)
+        exit(1)
+
+    os.environ["VCPKG_TRIPLET"] = triplet
+
+    # Base CMake arguments
+    cmake_args = [
+        "cmake",
+        f"-DCMAKE_BUILD_TYPE={RELEASE_CONFIG}",
+        "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+        "-DGIT_LFS_SKIP_SMUDGE=1",
+        "-DVCPKG_TRIPLET=%s" % triplet,
+    ]
+
+    # Platform-specific CMake arguments
+    if is_windows():
+        cmake_args.append("-DCESIUM_MSVC_STATIC_RUNTIME_ENABLED=ON")
+    elif is_macos():
+        cmake_args.extend([
+            "-DCMAKE_OSX_DEPLOYMENT_TARGET=11.0",
+        ])
+        # Set architecture for cross-compilation if specified
+        if arch in ("arm64", "aarch64"):
+            cmake_args.append("-DCMAKE_OSX_ARCHITECTURES=arm64")
+        elif arch in ("x86_64", "x64"):
+            cmake_args.append("-DCMAKE_OSX_ARCHITECTURES=x86_64")
+
+    cmake_args.append(".")
+
+    result = subprocess.run(cmake_args)
+
     if result.returncode != 0:
         errorMsg = "cmake return code: %s" % str(result.returncode)
         print(
@@ -200,11 +371,22 @@ def configure_native(argumentsDict):
     print("Configuration completed without any errors!")
 
 
-def determine_triplet():
-    if os.name == OS_WIN:
+def determine_triplet(arch: str = None):
+    """Determine the vcpkg triplet for the current platform and architecture"""
+    if is_windows():
         return "x64-windows-static"
-    if os.name == OS_LINUX:
+    if is_macos():
+        # Detect architecture - use provided arch or auto-detect
+        if arch is None:
+            import platform
+            arch = platform.machine()
+        if arch in ("arm64", "aarch64"):
+            return "arm64-osx"
+        else:
+            return "x64-osx"
+    if is_linux():
         return "x64-linux"
+    return None
 
 
 def compile_native(argumentsDict):
@@ -228,13 +410,15 @@ def compile_native(argumentsDict):
 
     # TODO: Test if we can just do cmake --build for all platforms
     result = None
-    if os.name == OS_WIN:
+    if is_windows():
         result = build_native_win()
-    elif os.name == OS_LINUX:
+    elif is_macos():
+        result = build_native_macos()
+    elif is_linux():
         result = build_native_linux()
     else:
         print(
-            "Compiling for platform %s is not yet supported!" % os.name, file=sys.stderr
+            "Compiling for platform %s (sys.platform=%s) is not yet supported!" % (os.name, sys.platform), file=sys.stderr
         )
     if result.returncode != 0:
         print("Error building Cesium Native: %s" % str(result.stderr))
@@ -245,6 +429,13 @@ def compile_native(argumentsDict):
 
 def build_native_linux():
     return subprocess.run(["cmake", "--build", "."])
+
+
+def build_native_macos():
+    """Build Cesium Native on macOS using cmake --build with parallel jobs"""
+    import multiprocessing
+    num_jobs = multiprocessing.cpu_count()
+    return subprocess.run(["cmake", "--build", ".", "--parallel", str(num_jobs)])
 
 
 def build_native_win():
@@ -294,12 +485,15 @@ def clean_cesium_definitions():
 def install_additional_libs():
     print("Installing additional libraries")
     vcpkgPath = find_ezvcpkg_path()
-    execExtension = ".exe" if os.name == OS_WIN else ""
+    execExtension = ".exe" if is_windows() else ""
     executable = "%s/%s" % (vcpkgPath, "vcpkg" + execExtension)
     subprocess.run([executable, "install", "uriparser:%s" % (determine_triplet())])
     subprocess.run([executable, "install", "ada-url:%s" % (determine_triplet())])
-    if os.name == OS_WIN:
+    if is_windows():
         subprocess.run([executable, "install", "curl:%s" % (determine_triplet())])
+    if is_macos():
+        # Build litehtml from source for macOS (vcpkg version lacks utf32 support)
+        build_litehtml_macos()
 
 
 def find_ms_build() -> str:

--- a/SConstruct.py
+++ b/SConstruct.py
@@ -31,7 +31,7 @@ cesium_build_utils.install_additional_libs()
 compilationTarget: str = cesium_build_utils.get_compile_target_definition(ARGUMENTS)
 
 env.Append(CPPDEFINES=[compilationTarget])
-if (os.name == cesium_build_utils.OS_LINUX):
+if cesium_build_utils.is_linux() or cesium_build_utils.is_macos():
     env.Append(CPPDEFINES=["CURL_STATIC_LIB", "SQLITE_STATIC"])
 env.__class__.add_source_files = add_source_files
 
@@ -43,19 +43,12 @@ SConscript("cesium_godot/SCsub", exports="env")
 
 
 # Create shared library
-if env["platform"] == "macos":
-    library = env.SharedLibrary(
-        "godot3dtiles/addons/cesium_godot/lib/{}.{}.{}.framework/helloWorld.{}.{}".format(
-            LIB_NAME, env["platform"], env["target"], env["platform"], env["target"]
-        ),
-        source=sources,
-    )
-else:
-    library = env.SharedLibrary(
-        "godot3dtiles/addons/cesium_godot/lib/{}{}{}".format(
-            LIB_NAME, env["suffix"], env["SHLIBSUFFIX"]),
-        source=sources,
-    )
+# Output path matches the naming convention in Godot3DTiles.gdextension
+library = env.SharedLibrary(
+    "godot3dtiles/addons/cesium_godot/lib/{}{}{}".format(
+        LIB_NAME, env["suffix"], env["SHLIBSUFFIX"]),
+    source=sources,
+)
 
 # Set the default target
 Default(library)

--- a/cesium_godot/Implementations/GodotPrepareRenderResources.cpp
+++ b/cesium_godot/Implementations/GodotPrepareRenderResources.cpp
@@ -145,7 +145,7 @@ void GodotPrepareRenderResources::free(Tile& tile, void* pLoadThreadResult, void
 	const auto& tileId = tile.getTileID();
 	size_t hash = std::visit(CesiumVariantHash{}, tileId);
 	auto* instance = static_cast<Cesium3DTile*>(pMainThreadResult);
-	this->m_tileset->call_deferred("free_tile", instance, hash);
+	this->m_tileset->call_deferred("free_tile", instance, static_cast<uint64_t>(hash));
 }
 
 void GodotPrepareRenderResources::attachRasterInMainThread(const Tile& tile, int32_t overlayTextureCoordinateID, const CesiumRasterOverlays::RasterOverlayTile& rasterTile, void* pMainThreadRendererResources, const glm::dvec2& translation, const glm::dvec2& scale)

--- a/cesium_godot/Models/CesiumGDTileset.cpp
+++ b/cesium_godot/Models/CesiumGDTileset.cpp
@@ -421,7 +421,7 @@ void Cesium3DTileset::add_overlay(CesiumIonRasterOverlay* overlay)
 	this->m_activeTileset->getOverlays().add(overlay->get_overlay_instance());
 }
 
-void Cesium3DTileset::free_tile(Cesium3DTile* tileInstance, size_t tileHash) {
+void Cesium3DTileset::free_tile(Cesium3DTile* tileInstance, uint64_t tileHash) {
 	if (tileInstance == nullptr) {
 		return;
 	}

--- a/cesium_godot/Models/CesiumGDTileset.h
+++ b/cesium_godot/Models/CesiumGDTileset.h
@@ -108,7 +108,7 @@ public:
 
 	void add_overlay(CesiumIonRasterOverlay* overlay);
 
-	void free_tile(Cesium3DTile* tileInstance, size_t tileHash);
+	void free_tile(Cesium3DTile* tileInstance, uint64_t tileHash);
 	
 	bool is_georeferenced(CesiumGeoreference** outRef) const;
 

--- a/cesium_godot/Models/TileMetadata.h
+++ b/cesium_godot/Models/TileMetadata.h
@@ -181,9 +181,8 @@ private:
 
 	template<class T>
 	CesiumPropertyInfo make_array_type(const T& nativeValue) {
-		CesiumPropertyInfo result{
-			.isArray = true
-		};
+		CesiumPropertyInfo result;
+		result.isArray = true;
 		Array data = Array();
 		data.resize(nativeValue.size());
 

--- a/cesium_godot/SCsub
+++ b/cesium_godot/SCsub
@@ -17,7 +17,7 @@ def load_cesium_module(p_includePaths: list[str], moduleName: str, loadSources=F
 
 
 env.Append(CPPDEFINES=[("_HAS_EXCEPTIONS", 1)])
-if os.name == cesium_build_utils.OS_WIN:
+if cesium_build_utils.is_windows():
     env.Append(CXXFLAGS=["/EHsc"])
 env.Append(CPPDEFINES=["SPDLOG_NO_EXCEPTIONS",
                        "LIBASYNC_NO_EXCEPTIONS"])
@@ -99,8 +99,9 @@ env.Prepend(LIBPATH=vcpkgLibPath)
 
 root_dir_native = cesium_build_utils.get_root_dir_native()
 current_build_config = ""
-if (os.name  == cesium_build_utils.OS_WIN):
+if cesium_build_utils.is_windows():
     current_build_config = cesium_build_utils.RELEASE_CONFIG
+# On macOS and Linux, libraries are in the root of each module directory (no Release subdirectory)
 # Library paths and linking
 libraries = [
     "Cesium3DTilesSelection",
@@ -142,7 +143,7 @@ libraries = [
     "gumbo"
 ]
 
-if (os.name == cesium_build_utils.OS_WIN):
+if cesium_build_utils.is_windows():
     libraries.extend([
         "absl_bad_any_cast_impl",
         "absl_bad_optional_access",
@@ -235,41 +236,69 @@ if (os.name == cesium_build_utils.OS_WIN):
         "zlibstatic-ng",
         "libmodpbase64"
     ])
-elif (os.name == cesium_build_utils.OS_LINUX):
+elif cesium_build_utils.is_macos():
+    libraries.extend([
+        "crypto",
+        "z-ng",  # zlib-ng provides zng_* functions used by ktx and other libs
+        "liblibmodpbase64"
+    ])
+elif cesium_build_utils.is_linux():
     libraries.extend([
         "crypto",
         "libz-ng",
         "liblibmodpbase64"
     ])
-    env.Append(LIBPATH=["/usr/lib/x86_64-linux-gnu"])
-    env.Append(CPPPATH=["/usr/include/x86_64-linux-gnu"])
+    # Get architecture for proper library paths
+    import platform
+    arch = platform.machine()
+    if arch == "x86_64":
+        env.Append(LIBPATH=["/usr/lib/x86_64-linux-gnu"])
+        env.Append(CPPPATH=["/usr/include/x86_64-linux-gnu"])
+    elif arch == "aarch64":
+        env.Append(LIBPATH=["/usr/lib/aarch64-linux-gnu"])
+        env.Append(CPPPATH=["/usr/include/aarch64-linux-gnu"])
 
-env.Append(
-    LIBS=libraries,
-    LIBPATH=[
-        f"{root_dir_native}/CesiumGltfReader/{current_build_config}",
-        f"{root_dir_native}/CesiumAsync/{current_build_config}",
-        f"{root_dir_native}/CesiumJsonReader/{current_build_config}",
-        f"{root_dir_native}/CesiumJsonWriter/{current_build_config}",
-        f"{root_dir_native}/CesiumGltf/{current_build_config}",
-        f"{root_dir_native}/CesiumUtility/{current_build_config}",
-        f"{root_dir_native}/CesiumGeospatial/{current_build_config}",
-        f"{root_dir_native}/Cesium3DTilesSelection/{current_build_config}",
-        f"{root_dir_native}/CesiumRasterOverlays/{current_build_config}",
-        f"{root_dir_native}/CesiumGeometry/{current_build_config}",
-        f"{root_dir_native}/Cesium3DTilesReader/{current_build_config}",
-        f"{root_dir_native}/CesiumGltfContent/{current_build_config}",
-        f"{root_dir_native}/CesiumQuantizedMeshTerrain/{current_build_config}",
-        f"{root_dir_native}/Cesium3DTilesContent/{current_build_config}",
+# Build library paths list
+lib_paths = [
+    f"{root_dir_native}/CesiumGltfReader/{current_build_config}",
+    f"{root_dir_native}/CesiumAsync/{current_build_config}",
+    f"{root_dir_native}/CesiumJsonReader/{current_build_config}",
+    f"{root_dir_native}/CesiumJsonWriter/{current_build_config}",
+    f"{root_dir_native}/CesiumGltf/{current_build_config}",
+    f"{root_dir_native}/CesiumUtility/{current_build_config}",
+    f"{root_dir_native}/CesiumGeospatial/{current_build_config}",
+    f"{root_dir_native}/Cesium3DTilesSelection/{current_build_config}",
+    f"{root_dir_native}/CesiumRasterOverlays/{current_build_config}",
+    f"{root_dir_native}/CesiumGeometry/{current_build_config}",
+    f"{root_dir_native}/Cesium3DTilesReader/{current_build_config}",
+    f"{root_dir_native}/CesiumGltfContent/{current_build_config}",
+    f"{root_dir_native}/CesiumQuantizedMeshTerrain/{current_build_config}",
+    f"{root_dir_native}/Cesium3DTilesContent/{current_build_config}",
+    cesium_build_utils.find_ezvcpkg_path() + "/installed/%s/lib" % (cesium_build_utils.determine_triplet())
+]
+
+# Platform-specific library paths
+if cesium_build_utils.is_macos():
+    # On macOS, we build litehtml from source and place it in third_party/litehtml/macos
+    # Use Prepend to ensure our litehtml takes precedence over vcpkg's incompatible version
+    env.Prepend(LIBPATH=[cesium_build_utils.get_root_dir() + "/third_party/litehtml/macos"])
+else:
+    # Windows/Linux paths
+    lib_paths.extend([
         cesium_build_utils.get_root_dir_native() + "/libs/gsl",
         cesium_build_utils.get_root_dir_native() + "/libs/absl",
         cesium_build_utils.get_root_dir_native() + "/libs",
         cesium_build_utils.get_root_dir() + "/third_party/litehtml",
-        cesium_build_utils.find_ezvcpkg_path(
-        ) + "/installed/%s/lib" % (cesium_build_utils.determine_triplet())
-    ]
+    ])
+
+env.Append(
+    LIBS=libraries,
+    LIBPATH=lib_paths
 )
 
 # This was a nightmare, so I abstracted it into a function, the function itself is also a nightmare
-if (os.name == cesium_build_utils.OS_LINUX):
+if cesium_build_utils.is_linux():
     cesium_build_utils.link_abseil_libs(env)
+elif cesium_build_utils.is_macos():
+    cesium_build_utils.link_abseil_libs_macos(env)
+    cesium_build_utils.link_macos_frameworks(env)

--- a/cesium_godot/Utils/CurlHttpClient.h
+++ b/cesium_godot/Utils/CurlHttpClient.h
@@ -16,9 +16,11 @@
 #include "godot_cpp/core/error_macros.hpp"
 #include <godot_cpp/templates/vector.hpp>
 #include "godot_cpp/classes/http_client.hpp"
+#include "godot_cpp/classes/marshalls.hpp"
 using namespace godot;
 #elif defined(CESIUM_GD_MODULE)
 #include "core/templates/vector.h"
+#include "core/io/marshalls.h"
 #endif
 
 #include "BRThreadPool.h"
@@ -51,8 +53,16 @@ struct RequestHandle_t {
 	void easy_init() {
 		this->curlHandle = curl_easy_init();
 		this->available = true;
+#ifdef __APPLE__
+		// macOS: Use system SSL (SecureTransport) with normal verification
+		// Don't disable SSL_VERIFYHOST as it also disables SNI which breaks modern servers
+		curl_easy_setopt(this->curlHandle, CURLOPT_SSL_VERIFYPEER, 1L);
+		curl_easy_setopt(this->curlHandle, CURLOPT_SSL_VERIFYHOST, 2L);
+#else
+		// Other platforms: disable SSL verification (original behavior)
 		curl_easy_setopt(this->curlHandle, CURLOPT_SSL_VERIFYPEER, 0L);
 		curl_easy_setopt(this->curlHandle, CURLOPT_SSL_VERIFYHOST, 0L);
+#endif
 		curl_easy_setopt(this->curlHandle, CURLOPT_FOLLOWLOCATION, 1);
 		curl_easy_setopt(this->curlHandle, CURLOPT_VERBOSE, 0);
 	}
@@ -170,6 +180,26 @@ private:
 
 	PackedByteArray pull_url(const char *url, CURL *handle, long*outStatus , const std::vector<CesiumHeader_t> &headers) {
 		PackedByteArray buffer;
+
+		// Handle data: URIs (base64-encoded inline data)
+		std::string urlStr(url);
+		if (urlStr.rfind("data:", 0) == 0) {
+			// Find the base64 marker
+			size_t base64Pos = urlStr.find(";base64,");
+			if (base64Pos != std::string::npos) {
+				std::string base64Data = urlStr.substr(base64Pos + 8);
+				// Use Godot's Marshalls class to decode base64
+				String godotBase64 = String(base64Data.c_str());
+				buffer = Marshalls::get_singleton()->base64_to_raw(godotBase64);
+				*outStatus = 200;
+				return buffer;
+			}
+			// Invalid data URI format
+			ERR_PRINT(String("Invalid data URI format: ") + url);
+			*outStatus = 400;
+			return PackedByteArray();
+		}
+
 		//Options stuff
 		curl_easy_setopt(handle, CURLOPT_URL, url);
 		curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, &CurlHttpClient::write_callback);

--- a/godot3dtiles/addons/cesium_godot/Godot3DTiles.gdextension
+++ b/godot3dtiles/addons/cesium_godot/Godot3DTiles.gdextension
@@ -10,6 +10,10 @@ windows.debug.x86_64 = "res://addons/cesium_godot/lib/Godot3DTiles.windows.templ
 windows.release.x86_64 = "res://addons/cesium_godot/lib/Godot3DTiles.windows.template_release.x86_64.dll"
 linux.debug.x86_64 = "res://addons/cesium_godot/lib/libGodot3DTiles.linux.template_release.x86_64.so"
 linux.release.x86_64 = "res://addons/cesium_godot/lib/libGodot3DTiles.linux.template_release.x86_64.so"
+macos.debug.arm64 = "res://addons/cesium_godot/lib/libGodot3DTiles.macos.template_release.arm64.dylib"
+macos.release.arm64 = "res://addons/cesium_godot/lib/libGodot3DTiles.macos.template_release.arm64.dylib"
+macos.debug.x86_64 = "res://addons/cesium_godot/lib/libGodot3DTiles.macos.template_release.x86_64.dylib"
+macos.release.x86_64 = "res://addons/cesium_godot/lib/libGodot3DTiles.macos.template_release.x86_64.dylib"
 
 
 [icons]

--- a/godot3dtiles/addons/cesium_godot/scripts/camera_controllers/AbstractCesiumCamera.gd
+++ b/godot3dtiles/addons/cesium_godot/scripts/camera_controllers/AbstractCesiumCamera.gd
@@ -31,6 +31,10 @@ func find_directional_light(node: Node) -> DirectionalLight3D:
 	return null
 
 func _ready() -> void:
+	# Auto-discover tilesets if not explicitly set
+	if self.tilesets.is_empty() and self.globe_node:
+		self.tilesets = _find_all_tilesets(self.globe_node)
+
 	# This is a workaround for the fact that you can't detect double precision builds in GDScript
 	# but you probably aren't using TrueOrigin in a single precision build
 	if self.globe_node.origin_type == CesiumGeoreference.CartographicOrigin:
@@ -71,3 +75,12 @@ func _update_tilesets() -> void:
 	for tileset in self.tilesets:
 		if (tileset == null): continue
 		tileset.update_tileset(camera_xform)
+
+
+func _find_all_tilesets(node: Node) -> Array[Cesium3DTileset]:
+	var result: Array[Cesium3DTileset] = []
+	if node is Cesium3DTileset:
+		result.append(node)
+	for child in node.get_children():
+		result.append_array(_find_all_tilesets(child))
+	return result


### PR DESCRIPTION
## Summary
- Adds macOS ARM64 build support to the GDExtension
- Fixes SSL/SNI issues with curl on macOS (SecureTransport requires SNI for modern servers)
- Adds data URI handling for Cesium credit system images (base64-encoded inline logos)
- Auto-discovers tilesets in camera if not explicitly set

## Changes
- **Build system**: Updated SCons/CMake to support macOS with vcpkg and litehtml from source
- **CurlHttpClient.h**: Enable proper SSL verification on macOS (don't disable SNI), handle data: URIs
- **AbstractCesiumCamera.gd**: Auto-discover tilesets from globe_node at runtime
- **Godot3DTiles.gdextension**: Added macOS library entries

## Test plan
- [x] Build on macOS ARM64 with `scons arch=arm64 compileTarget=extension target=template_release`
- [x] Install plugin in fresh Godot 4.5 project
- [x] Connect to Cesium Ion via plugin UI
- [x] Add Cesium World Terrain via plugin UI
- [x] Add CesiumDynamicCamera via plugin UI
- [x] Verify 3D tiles render correctly without code workarounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)