### PR TITLE
CesiumIonRasterOverlay now takes URL

### DIFF
--- a/cesium_godot/Models/CesiumGDRasterOverlay.cpp
+++ b/cesium_godot/Models/CesiumGDRasterOverlay.cpp
@@ -1,5 +1,6 @@
 #include "CesiumGDRasterOverlay.h"
 #include <CesiumRasterOverlays/IonRasterOverlay.h>
+#include <CesiumRasterOverlays/TileMapServiceRasterOverlay.h>
 #include "CesiumGDTileset.h"
 #include "CesiumGDConfig.h"
 
@@ -23,10 +24,35 @@ const String& CesiumIonRasterOverlay::get_material_key() const
 	return this->m_materialKey;
 }
 
+void CesiumIonRasterOverlay::set_url(const String& url)
+{
+	this->m_url = url;
+}
+
+const String& CesiumIonRasterOverlay::get_url() const
+{
+	return this->m_url;
+}
+
+int CesiumIonRasterOverlay::get_data_source() const
+{
+	return static_cast<int>(this->m_selectedDataSource);
+}
+
+void CesiumIonRasterOverlay::set_data_source(int data_source)
+{
+	this->m_selectedDataSource = static_cast<CesiumDataSource>(data_source);
+	this->notify_property_list_changed();
+}
+
 Error CesiumIonRasterOverlay::add_to_tileset(Cesium3DTileset* tilesetInstance)
 {
 	if (tilesetInstance == nullptr) return Error::ERR_INVALID_PARAMETER;
-	if (this->m_assetId <= 0) return Error::ERR_CANT_ACQUIRE_RESOURCE;
+	if (this->m_selectedDataSource == CesiumDataSource::FromCesiumIon) {
+		if (this->m_assetId <= 0) return Error::ERR_CANT_ACQUIRE_RESOURCE;
+	} else {
+		if (this->m_url.is_empty()) return Error::ERR_CANT_ACQUIRE_RESOURCE;
+	}
 
 	//Overlay already added
 	if (this->m_overlayInstance != nullptr) return Error::OK;
@@ -40,20 +66,32 @@ void CesiumIonRasterOverlay::remove_from_tileset(Cesium3DTileset* tilesetInstanc
 
 }
 
-CesiumUtility::IntrusivePointer<CesiumRasterOverlays::IonRasterOverlay> CesiumIonRasterOverlay::get_overlay_instance()
+CesiumUtility::IntrusivePointer<CesiumRasterOverlays::RasterOverlay> CesiumIonRasterOverlay::get_overlay_instance()
 {
 	return this->m_overlayInstance;
 }
 
 void CesiumIonRasterOverlay::create_and_add_overlay(Cesium3DTileset* tilesetInstance)
 {
-	const String& ionAccessToken = CesiumGDConfig::get_singleton(this)->get_access_token();
-	this->m_overlayInstance = new CesiumRasterOverlays::IonRasterOverlay(
-		this->m_materialKey.utf8().get_data(),
-		this->m_assetId,
-		ionAccessToken.utf8().get_data(),
-		{}
-	);
+	if (this->m_selectedDataSource == CesiumDataSource::FromCesiumIon) {
+		const String& ionAccessToken = CesiumGDConfig::get_singleton(this)->get_access_token();
+		this->m_overlayInstance = new CesiumRasterOverlays::IonRasterOverlay(
+			this->m_materialKey.utf8().get_data(),
+			this->m_assetId,
+			ionAccessToken.utf8().get_data(),
+			{}
+		);
+	}
+	else {
+		CesiumRasterOverlays::TileMapServiceRasterOverlayOptions options{};
+		
+		this->m_overlayInstance = new CesiumRasterOverlays::TileMapServiceRasterOverlay(
+			this->m_materialKey.utf8().get_data(),
+			this->m_url.utf8().get_data(),
+			std::vector<CesiumAsync::IAssetAccessor::THeader>{},
+			options
+		);
+	}
 	tilesetInstance->add_overlay(this);
 }
 
@@ -68,4 +106,60 @@ void CesiumIonRasterOverlay::_bind_methods()
 	ClassDB::bind_method(D_METHOD("set_asset_id", "id"), &CesiumIonRasterOverlay::set_asset_id);
 	ClassDB::bind_method(D_METHOD("get_asset_id"), &CesiumIonRasterOverlay::get_asset_id);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "asset_id"), "set_asset_id", "get_asset_id");
+
+	ClassDB::bind_method(D_METHOD("get_data_source"), &CesiumIonRasterOverlay::get_data_source);
+	ClassDB::bind_method(D_METHOD("set_data_source", "data_source"), &CesiumIonRasterOverlay::set_data_source);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "data_source", PROPERTY_HINT_ENUM, "From Cesium Ion,From Url"), "set_data_source", "get_data_source");
+	
+	ClassDB::bind_method(D_METHOD("set_url", "url"), &CesiumIonRasterOverlay::set_url);
+	ClassDB::bind_method(D_METHOD("get_url"), &CesiumIonRasterOverlay::get_url);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "url"), "set_url", "get_url");
+	
+	ClassDB::bind_integer_constant(get_class_static(), "CesiumDataSource", "FromCesiumIon", static_cast<int32_t>(CesiumDataSource::FromCesiumIon));
+	ClassDB::bind_integer_constant(get_class_static(), "CesiumDataSource", "FromUrl", static_cast<int32_t>(CesiumDataSource::FromUrl));
+}
+
+void CesiumIonRasterOverlay::_get_property_list(List<PropertyInfo>* properties) const
+{
+	#if defined(CESIUM_GD_MODULE)
+	for (int32_t i = 0; i < properties->size(); i++) {
+		PropertyInfo& propertyRef = properties->get(i);
+	#elif defined(CESIUM_GD_EXT)
+	for (auto it = properties->begin(); it != properties->end(); ++it) {
+		PropertyInfo& propertyRef = *it;
+	#endif
+		if (propertyRef.name == StringName("url")) {
+			propertyRef.usage = this->m_selectedDataSource == CesiumDataSource::FromCesiumIon ? PROPERTY_USAGE_READ_ONLY : PROPERTY_USAGE_DEFAULT;
+		}
+		if (propertyRef.name == StringName("asset_id")) {
+			propertyRef.usage = this->m_selectedDataSource == CesiumDataSource::FromCesiumIon ? PROPERTY_USAGE_DEFAULT : PROPERTY_USAGE_READ_ONLY;
+		}
+	}
+}
+
+bool CesiumIonRasterOverlay::_set(const StringName& p_name, const Variant& p_property)
+{
+	if (p_name == StringName("url")) {
+		this->set_url(p_property);
+		return true;
+	}
+	if (p_name == StringName("asset_id")) {
+		this->set_asset_id(p_property);
+		return true;
+	}
+	return false;
+}
+
+bool CesiumIonRasterOverlay::_get(const StringName& p_name, Variant& r_property) const
+{
+	if (p_name == StringName("url")) {
+		r_property = this->get_url();
+		return true;
+	}
+	if (p_name == StringName("asset_id")) {
+		r_property = this->get_asset_id();
+		return true;
+	}
+
+	return false;
 }

--- a/cesium_godot/Models/CesiumGDRasterOverlay.h
+++ b/cesium_godot/Models/CesiumGDRasterOverlay.h
@@ -14,6 +14,8 @@ using namespace godot;
 
 #include <CesiumUtility/IntrusivePointer.h>
 #include <CesiumRasterOverlays/IonRasterOverlay.h>
+#include <CesiumRasterOverlays/TileMapServiceRasterOverlay.h>
+#include "CesiumDataSource.h"
 
 class Cesium3DTileset;
 
@@ -31,13 +33,21 @@ public:
 
 	const String& get_material_key() const;
 
+	void set_url(const String& url);
+
+	const String& get_url() const;
+
+	int get_data_source() const;
+
+	void set_data_source(int data_source);
+
 #pragma endregion
 
 	Error add_to_tileset(Cesium3DTileset* tilesetInstance);
 
 	void remove_from_tileset(Cesium3DTileset* tilesetInstance);
 
-	CesiumUtility::IntrusivePointer<CesiumRasterOverlays::IonRasterOverlay> get_overlay_instance();
+	CesiumUtility::IntrusivePointer<CesiumRasterOverlays::RasterOverlay> get_overlay_instance();
 
 private:
 
@@ -46,12 +56,22 @@ private:
 
 	int64_t m_assetId = 0;
 
-	String m_materialKey = "0";
+	String m_materialKey = "overlay";
 
-	CesiumUtility::IntrusivePointer<CesiumRasterOverlays::IonRasterOverlay> m_overlayInstance;
+	String m_url = "";
+
+	CesiumDataSource m_selectedDataSource = CesiumDataSource::FromCesiumIon;
+
+	CesiumUtility::IntrusivePointer<CesiumRasterOverlays::RasterOverlay> m_overlayInstance;
+
 
 protected:
 	static void _bind_methods();
+
+	void _get_property_list(List<PropertyInfo>* properties) const;
+
+	bool _set(const StringName& p_name, const Variant& p_property);
+	bool _get(const StringName& p_name, Variant& r_property) const;
 };
 
 #endif // !CESIUM_GD_RASTER_OVERLAY_H


### PR DESCRIPTION
Like `Cesium3DTileset`, `CesiumIonRasterOverlay` now lets the user set sources to be URL. 

This allows for locally hosted Cesium data to be loaded into the tiles.